### PR TITLE
fix: update static_replace import to work with lilac

### DIFF
--- a/image_explorer/image_explorer.py
+++ b/image_explorer/image_explorer.py
@@ -333,7 +333,7 @@ class ImageExplorerBlock(XBlock):  # pylint: disable=no-init
         if not url:
             return url
         try:
-            from static_replace import replace_static_urls
+            from common.djangoapps.static_replace import replace_static_urls
         except ImportError:
             return url
 


### PR DESCRIPTION
This PR makes a little fix to the xblock in order to be used in lilac versions.